### PR TITLE
running "cndi terraform foo" calls terraform in CNDI context

### DIFF
--- a/src/cndi.ts
+++ b/src/cndi.ts
@@ -18,6 +18,7 @@ import initFn from "./commands/init.ts";
 import overwriteWithFn from "./commands/overwrite-with.ts";
 import helpFn from "./commands/help.ts";
 import installFn from "./commands/install.ts";
+import terraformFn from "./commands/terraform.ts";
 
 export default async function main(args: string[]) {
   const fileSuffixForPlatform = getFileSuffixForPlatform();
@@ -111,6 +112,7 @@ export default async function main(args: string[]) {
     [Command.run]: runFn,
     [Command.help]: helpFn,
     [Command.install]: installFn,
+    [Command.terraform]: terraformFn,
     [Command.default]: (c: string) => {
       console.log(
         `Command "${c}" not found. Use "cndi --help" for more information.`,
@@ -161,6 +163,9 @@ export default async function main(args: string[]) {
         break;
       case Command.ow:
         commands[Command["overwrite-with"]](context);
+        break;
+      case Command.terraform:
+        commands[Command.terraform](context, args.slice(1));
         break;
       default:
         commands[Command.default](operation);

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -11,10 +11,8 @@ const runFn = async ({
   pathToTerraformResources,
 }: CNDIContext) => {
   console.log("cndi run");
-  try { 
-
+  try {
     setTF_VARs(); // set TF_VARs using CNDI's .env variables
-
 
     // terraform.tfstate will be in this folder after the first run
     const ranTerraformInit = await Deno.run({

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -1,6 +1,6 @@
 import "https://deno.land/std@0.157.0/dotenv/load.ts";
+import setTF_VARs from "../setTF_VARs.ts";
 import { CNDIContext } from "../types.ts";
-import { padPrivatePem, padPublicPem } from "../utils.ts";
 
 /**
  * COMMAND fn: cndi run
@@ -11,67 +11,10 @@ const runFn = async ({
   pathToTerraformResources,
 }: CNDIContext) => {
   console.log("cndi run");
-  try {
-    const git_username = Deno.env.get("GIT_USERNAME");
-    if (!git_username) {
-      console.error("GIT_USERNAME env var is not set");
-      Deno.exit(31);
-    }
+  try { 
 
-    const git_password = Deno.env.get("GIT_PASSWORD");
-    if (!git_password) {
-      console.error("GIT_PASSWORD env var is not set");
-      Deno.exit(32);
-    }
+    setTF_VARs(); // set TF_VARs using CNDI's .env variables
 
-    const git_repo = Deno.env.get("GIT_REPO");
-    if (!git_repo) {
-      console.error("GIT_REPO env var is not set");
-      Deno.exit(33);
-    }
-
-    const argoui_readonly_password = Deno.env.get("ARGOUI_READONLY_PASSWORD");
-    if (!argoui_readonly_password) {
-      console.error("ARGOUI_READONLY_PASSWORD env var is not set");
-      Deno.exit(34);
-    }
-
-    const sealed_secrets_private_key_material = Deno.env.get(
-      "SEALED_SECRETS_PRIVATE_KEY_MATERIAL",
-    )?.trim().replaceAll("_", "\n");
-
-    if (!sealed_secrets_private_key_material) {
-      console.error("SEALED_SECRETS_PRIVATE_KEY_MATERIAL env var is not set");
-      Deno.exit(35);
-    }
-
-    const sealed_secrets_public_key_material = Deno.env.get(
-      "SEALED_SECRETS_PUBLIC_KEY_MATERIAL",
-    )?.trim().replaceAll("_", "\n");
-    if (!sealed_secrets_public_key_material) {
-      console.error("SEALED_SECRETS_PUBLIC_KEY_MATERIAL env var is not set");
-      Deno.exit(36);
-    }
-
-    const sealed_secrets_private_key = padPrivatePem(
-      sealed_secrets_private_key_material,
-    );
-    const sealed_secrets_public_key = padPublicPem(
-      sealed_secrets_public_key_material,
-    );
-
-    Deno.env.set("TF_VAR_git_username", git_username);
-    Deno.env.set("TF_VAR_git_password", git_password);
-    Deno.env.set("TF_VAR_git_repo", git_repo);
-    Deno.env.set("TF_VAR_argoui_readonly_password", argoui_readonly_password);
-    Deno.env.set(
-      "TF_VAR_sealed_secrets_public_key",
-      sealed_secrets_public_key,
-    );
-    Deno.env.set(
-      "TF_VAR_sealed_secrets_private_key",
-      sealed_secrets_private_key,
-    );
 
     // terraform.tfstate will be in this folder after the first run
     const ranTerraformInit = await Deno.run({
@@ -89,10 +32,11 @@ const runFn = async ({
     const initStderr = await ranTerraformInit.stderrOutput();
 
     if (initStatus.code !== 0) {
-      Deno.stdout.write(initStderr);
+      console.log("terraform init failed");
+      await Deno.stdout.write(initStderr);
       Deno.exit(251); // arbitrary exit code
     } else {
-      Deno.stdout.write(initOutput);
+      await Deno.stdout.write(initOutput);
     }
 
     ranTerraformInit.close();
@@ -113,10 +57,11 @@ const runFn = async ({
     const applyStderr = await ranTerraformApply.stderrOutput();
 
     if (applyStatus.code !== 0) {
-      Deno.stdout.write(applyStderr);
+      console.log("terraform apply failed");
+      await Deno.stdout.write(applyStderr);
       Deno.exit(252); // arbitrary exit code
     } else {
-      Deno.stdout.write(applyOutput);
+      await Deno.stdout.write(applyOutput);
     }
 
     ranTerraformApply.close();

--- a/src/commands/terraform.ts
+++ b/src/commands/terraform.ts
@@ -1,0 +1,33 @@
+import { CNDIContext } from "../types.ts";
+import setTF_VARs from "../setTF_VARs.ts";
+/**
+ * COMMAND fn: cndi terraform
+ * Wraps the terraform cli with a CNDI context
+ */
+export default async function terraform(
+  { pathToTerraformBinary, pathToTerraformResources }: CNDIContext,
+  args: string[]
+) {
+  console.log("cndi terraform", args.join(" "));
+
+  setTF_VARs(); // set TF_VARs using CNDI's .env variables
+
+  const ranProxiedTerraformCmd = Deno.run({
+    cmd: [pathToTerraformBinary, `-chdir=${pathToTerraformResources}`, ...args],
+    "stderr": "piped",
+    "stdout": "piped",
+  });
+
+  const proxiedTerraformCmdStatus = await ranProxiedTerraformCmd.status();
+  const proxiedTerraformCmdOutput = await ranProxiedTerraformCmd.output();
+  const proxiedTerraformCmdStderr = await ranProxiedTerraformCmd.stderrOutput();
+
+  if (proxiedTerraformCmdStatus.code !== 0) {
+    await Deno.stdout.write(proxiedTerraformCmdStderr);
+    Deno.exit(253); // arbitrary exit code
+  } else {
+    await Deno.stdout.write(proxiedTerraformCmdOutput);
+  }
+
+  ranProxiedTerraformCmd.close();
+}

--- a/src/commands/terraform.ts
+++ b/src/commands/terraform.ts
@@ -6,7 +6,7 @@ import setTF_VARs from "../setTF_VARs.ts";
  */
 export default async function terraform(
   { pathToTerraformBinary, pathToTerraformResources }: CNDIContext,
-  args: string[]
+  args: string[],
 ) {
   console.log("cndi terraform", args.join(" "));
 

--- a/src/setTF_VARs.ts
+++ b/src/setTF_VARs.ts
@@ -1,0 +1,60 @@
+import { padPrivatePem, padPublicPem } from "./utils.ts";
+
+export default function setTF_VARs() {
+  const git_username = Deno.env.get("GIT_USERNAME");
+  if (!git_username) {
+    console.error("GIT_USERNAME env var is not set");
+    Deno.exit(31);
+  }
+
+  const git_password = Deno.env.get("GIT_PASSWORD");
+  if (!git_password) {
+    console.error("GIT_PASSWORD env var is not set");
+    Deno.exit(32);
+  }
+
+  const git_repo = Deno.env.get("GIT_REPO");
+  if (!git_repo) {
+    console.error("GIT_REPO env var is not set");
+    Deno.exit(33);
+  }
+
+  const argoui_readonly_password = Deno.env.get("ARGOUI_READONLY_PASSWORD");
+  if (!argoui_readonly_password) {
+    console.error("ARGOUI_READONLY_PASSWORD env var is not set");
+    Deno.exit(34);
+  }
+
+  const sealed_secrets_private_key_material = Deno.env
+    .get("SEALED_SECRETS_PRIVATE_KEY_MATERIAL")
+    ?.trim()
+    .replaceAll("_", "\n");
+
+  if (!sealed_secrets_private_key_material) {
+    console.error("SEALED_SECRETS_PRIVATE_KEY_MATERIAL env var is not set");
+    Deno.exit(35);
+  }
+
+  const sealed_secrets_public_key_material = Deno.env
+    .get("SEALED_SECRETS_PUBLIC_KEY_MATERIAL")
+    ?.trim()
+    .replaceAll("_", "\n");
+  if (!sealed_secrets_public_key_material) {
+    console.error("SEALED_SECRETS_PUBLIC_KEY_MATERIAL env var is not set");
+    Deno.exit(36);
+  }
+
+  const sealed_secrets_private_key = padPrivatePem(
+    sealed_secrets_private_key_material
+  );
+  const sealed_secrets_public_key = padPublicPem(
+    sealed_secrets_public_key_material
+  );
+
+  Deno.env.set("TF_VAR_git_username", git_username);
+  Deno.env.set("TF_VAR_git_password", git_password);
+  Deno.env.set("TF_VAR_git_repo", git_repo);
+  Deno.env.set("TF_VAR_argoui_readonly_password", argoui_readonly_password);
+  Deno.env.set("TF_VAR_sealed_secrets_public_key", sealed_secrets_public_key);
+  Deno.env.set("TF_VAR_sealed_secrets_private_key", sealed_secrets_private_key);
+}

--- a/src/setTF_VARs.ts
+++ b/src/setTF_VARs.ts
@@ -45,10 +45,10 @@ export default function setTF_VARs() {
   }
 
   const sealed_secrets_private_key = padPrivatePem(
-    sealed_secrets_private_key_material
+    sealed_secrets_private_key_material,
   );
   const sealed_secrets_public_key = padPublicPem(
-    sealed_secrets_public_key_material
+    sealed_secrets_public_key_material,
   );
 
   Deno.env.set("TF_VAR_git_username", git_username);

--- a/src/templates/help-strings.ts
+++ b/src/templates/help-strings.ts
@@ -3,6 +3,7 @@ type HelpStrings = {
   init: string;
   install: string;
   "overwrite-with": string;
+  terraform: string;
   ow: string;
   run: string;
   help: string;
@@ -87,6 +88,14 @@ DESCRIPTION
         Fetches and unpacks files required for using cndi and installs them to the CNDI_HOME directory. 
         
         Must be run once before using cndi!
+  `.trim(),
+  terraform: `
+NAME
+        cndi-terrafrom - wraps the terraform cli so that it can be used within a cndi context
+SYNOPSIS
+        cndi terraform <command>
+DESCRIPTION
+        Runs the terraform CLI with the proper cndi environment variables set.
   `.trim(),
   help: `oops! "help" is not a command, you probably meant "--help"`,
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export const enum Command {
   help = "help",
   default = "default",
   install = "install",
+  terraform = "terraform",
   ow = "ow",
 }
 


### PR DESCRIPTION
Sometimes it can be useful to call `terraform` commands instead of `cndi run`. Mostly this is useful for debugging purposes.  Calling `terraform plan` will cause terraform to ask the user for the variables that CNDI is meant to inject automatically. 

Now the user can run `cndi terraform plan` or any other terraform cli command and we handle setting the variables for the user.

This is done by making the variable mapper a function called by both `cndi run` and `cndi terraform ...`