### PR TITLE
improved interactivity and ux, especially with secrets

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -1,15 +1,39 @@
-import { AirflowTlsTemplateAnswers, CNDIContext } from "../types.ts";
+import {
+  AirflowTlsTemplateAnswers,
+  CNDIContext,
+  EnvObject,
+  Template,
+} from "../types.ts";
+
+import { copy } from "https://deno.land/std@0.157.0/fs/copy.ts";
+
+import { trimPemString } from "../utils.ts";
+
 import { brightRed, cyan } from "https://deno.land/std@0.158.0/fmt/colors.ts";
 import * as path from "https://deno.land/std@0.157.0/path/mod.ts";
 import overwriteWithFn from "./overwrite-with.ts";
 
 import { Select } from "https://deno.land/x/cliffy@v0.25.4/prompt/select.ts";
+import { Secret } from "https://deno.land/x/cliffy@v0.25.4/prompt/secret.ts";
 import { Input } from "https://deno.land/x/cliffy@v0.25.4/prompt/mod.ts";
 
-import airflowTlsTemplate from "../templates/airflow-tls.ts";
+import { createSealedSecretsKeys } from "../initialize/sealedSecretsKeys.ts";
+
+import { createTerraformStatePassphrase } from "../initialize/terraformStatePassphrase.ts";
+
+import { createArgoUIReadOnlyPassword } from "../initialize/argoUIReadOnlyPassword.ts";
+
+import airflowTlsTemplate, {
+  getAirflowTlsTemplateEnvObject,
+} from "../templates/airflow-tls.ts";
 import basicTemplate from "../templates/basic.ts";
 
+import { checkInitialized } from "../utils.ts";
+
 import availableTemplates from "../templates/available-templates.ts";
+import writeEnvObject from "../outputs/env.ts";
+import getGitignoreContents from "../outputs/gitignore.ts";
+import getREADME from "../outputs/readme.ts";
 
 async function getAirflowTlsTemplateAnswers(
   context: CNDIContext,
@@ -22,33 +46,33 @@ async function getAirflowTlsTemplateAnswers(
   let letsEncryptClusterIssuerEmailAddress = "admin@example.com";
 
   if (interactive) {
-    argocdDomainName = await Input.prompt({
+    argocdDomainName = (await Input.prompt({
       message: cyan(
         "Please enter the domain name you want argocd to be accessible on:",
       ),
       default: argocdDomainName,
-    }) as string;
+    })) as string;
 
-    airflowDomainName = await Input.prompt({
+    airflowDomainName = (await Input.prompt({
       message: cyan(
         "Please enter the domain name you want airflow to be accessible on:",
       ),
       default: airflowDomainName,
-    }) as string;
+    })) as string;
 
-    dagRepoUrl = await Input.prompt({
+    dagRepoUrl = (await Input.prompt({
       message: cyan(
         "Please enter the url of the git repo containing your dags:",
       ),
       default: dagRepoUrl,
-    }) as string;
+    })) as string;
 
-    letsEncryptClusterIssuerEmailAddress = await Input.prompt({
+    letsEncryptClusterIssuerEmailAddress = (await Input.prompt({
       message: cyan(
         "Please enter the email address you want to use for lets encrypt:",
       ),
       default: letsEncryptClusterIssuerEmailAddress,
-    }) as string;
+    })) as string;
   }
 
   return {
@@ -72,17 +96,183 @@ const getTemplateString = async (
   }
 };
 
+const getCoreEnvObject = async (context: CNDIContext): Promise<EnvObject> => {
+  let GIT_USERNAME = "";
+  let GIT_REPO = "";
+  let GIT_PASSWORD = "";
+  let AWS_REGION = "us-east-1";
+  let AWS_ACCESS_KEY_ID = "";
+  let AWS_SECRET_ACCESS_KEY = "";
+
+  const {
+    sealedSecretsKeys,
+    terraformStatePassphrase,
+    argoUIReadOnlyPassword,
+  } = context;
+
+  const TERRAFORM_STATE_PASSPHRASE = terraformStatePassphrase;
+  const ARGO_UI_READONLY_PASSWORD = argoUIReadOnlyPassword;
+
+  if (!sealedSecretsKeys) {
+    throw new Error(`init: "sealedSecretsKeys" is not defined in context`);
+  }
+
+  if (!TERRAFORM_STATE_PASSPHRASE) {
+    throw new Error(
+      `init: "terraformStatePassphrase" is not defined in context`,
+    );
+  }
+
+  if (!ARGO_UI_READONLY_PASSWORD) {
+    throw new Error(`init: "argoUIReadOnlyPassword" is not defined in context`);
+  }
+
+  const SEALED_SECRETS_PUBLIC_KEY_MATERIAL = trimPemString(
+    sealedSecretsKeys.sealed_secrets_public_key,
+  ).replaceAll("\n", "_");
+
+  const SEALED_SECRETS_PRIVATE_KEY_MATERIAL = trimPemString(
+    sealedSecretsKeys.sealed_secrets_private_key,
+  ).replaceAll("\n", "_");
+
+  if (context.interactive) {
+    GIT_USERNAME = (await Input.prompt({
+      message: cyan("Enter your GitHub username:"),
+      default: GIT_USERNAME,
+    })) as string;
+
+    GIT_REPO = (await Input.prompt({
+      message: cyan("Enter your GitHub repository URL:"),
+      default: GIT_REPO,
+    })) as string;
+
+    GIT_PASSWORD = (await Secret.prompt({
+      message: cyan("Enter your GitHub Personal Access Token:"),
+      default: GIT_PASSWORD,
+    })) as string;
+
+    AWS_REGION = (await Input.prompt({
+      message: cyan("Enter your AWS region:"),
+      default: AWS_REGION,
+    })) as string;
+
+    AWS_ACCESS_KEY_ID = (await Secret.prompt({
+      message: cyan("Enter your AWS access key ID:"),
+      default: AWS_ACCESS_KEY_ID,
+    })) as string;
+
+    AWS_SECRET_ACCESS_KEY = (await Secret.prompt({
+      message: cyan("Enter your AWS secret access key:"),
+      default: AWS_SECRET_ACCESS_KEY,
+    })) as string;
+  }
+
+  return {
+    GIT_USERNAME: {
+      comment: "Git Credentials",
+      value: GIT_USERNAME,
+    },
+    GIT_REPO: {
+      value: GIT_REPO,
+    },
+    GIT_PASSWORD: {
+      value: GIT_PASSWORD,
+    },
+    AWS_REGION: {
+      comment: "AWS Credentials",
+      value: AWS_REGION,
+    },
+    AWS_ACCESS_KEY_ID: {
+      value: AWS_ACCESS_KEY_ID,
+    },
+    AWS_SECRET_ACCESS_KEY: {
+      value: AWS_SECRET_ACCESS_KEY,
+    },
+
+    SEALED_SECRETS_PUBLIC_KEY_MATERIAL: {
+      comment: "Sealed Secrets keys for Kubeseal",
+      value: SEALED_SECRETS_PUBLIC_KEY_MATERIAL,
+    },
+    SEALED_SECRETS_PRIVATE_KEY_MATERIAL: {
+      value: SEALED_SECRETS_PRIVATE_KEY_MATERIAL,
+    },
+    ARGO_UI_READONLY_PASSWORD: {
+      comment: "ArgoUI",
+      value: ARGO_UI_READONLY_PASSWORD,
+    },
+    TERRAFORM_STATE_PASSPHRASE: {
+      comment: "Passphrase for encrypting/decrypting terraform state",
+      value: TERRAFORM_STATE_PASSPHRASE,
+    },
+  };
+};
+
+const getEnvObject = async (context: CNDIContext): Promise<EnvObject> => {
+  const coreEnvObject = await getCoreEnvObject(context);
+
+  if (!context?.template) {
+    return coreEnvObject;
+  }
+
+  switch (context.template) {
+    case "airflow-tls":
+      return {
+        ...coreEnvObject,
+        ...(await getAirflowTlsTemplateEnvObject(context)),
+      };
+    case "basic":
+      return coreEnvObject;
+    default:
+      return coreEnvObject;
+  }
+};
+
 /**
  * COMMAND fn: cndi init
  * Initializes ./cndi directory with the specified config file
  * and initializes workflows in .github
  */
-export default async function init(context: CNDIContext) {
+export default async function init(c: CNDIContext) {
   const initializing = true;
   const CNDI_CONFIG_FILENAME = "cndi-config.jsonc";
 
-  const { projectDirectory, interactive } = context;
-  let { template } = context;
+  let template = c.template;
+
+  const directoryContainsCNDIFiles = await checkInitialized(c);
+
+  const shouldContinue = directoryContainsCNDIFiles
+    ? confirm(
+      "It looks like you have already initialized a cndi project in this directory. Overwrite existing artifacts?",
+    )
+    : true;
+
+  if (!shouldContinue) {
+    Deno.exit(0);
+  }
+
+  if (template && !availableTemplates.includes(template)) {
+    console.log(
+      brightRed(`The template you selected "${template}" is not available.\n`),
+    );
+
+    console.log("Available templates are:\n");
+    console.log(`${availableTemplates.map((t) => cyan(t)).join(", ")}\n`);
+    Deno.exit(1);
+  }
+
+  const sealedSecretsKeys = await createSealedSecretsKeys(c);
+  const terraformStatePassphrase = createTerraformStatePassphrase();
+  const argoUIReadOnlyPassword = createArgoUIReadOnlyPassword();
+
+  const context = {
+    ...c,
+    sealedSecretsKeys,
+    terraformStatePassphrase,
+    argoUIReadOnlyPassword,
+  };
+
+  const { noGitHub, CNDI_SRC, githubDirectory, interactive, projectDirectory } =
+    context;
 
   if (interactive && !template) {
     template = await Select.prompt({
@@ -94,21 +284,31 @@ export default async function init(context: CNDIContext) {
     });
   }
 
+  await Deno.writeTextFile(context.gitignorePath, getGitignoreContents());
+
+  const envObject = await getEnvObject({ ...context, template });
+  await writeEnvObject(context.dotEnvPath, envObject);
+
+  if (!noGitHub) {
+    try {
+      // overwrite the github workflows and readme, do not clobber other files
+      await copy(path.join(CNDI_SRC, "github"), githubDirectory, {
+        overwrite: true,
+      });
+    } catch (githubCopyError) {
+      console.log("failed to copy github integration files");
+      console.error(githubCopyError);
+    }
+  }
+
+  await Deno.writeTextFile(
+    path.join(context.projectDirectory, "README.md"),
+    getREADME((template as Template) || null),
+  );
+
   // if the user has specified a template, use that
   if (template) {
     console.log(`cndi init --template ${template}\n`);
-
-    if (!availableTemplates.includes(template)) {
-      console.log(
-        brightRed(
-          `The template you selected "${template}" is not available.\n`,
-        ),
-      );
-
-      console.log("Available templates are:\n");
-      console.log(`${availableTemplates.map((t) => cyan(t)).join(", ")}\n`);
-      return;
-    }
 
     const configOutputPath = path.join(projectDirectory, CNDI_CONFIG_FILENAME);
 

--- a/src/commands/overwrite-with.ts
+++ b/src/commands/overwrite-with.ts
@@ -1,12 +1,5 @@
 import * as path from "https://deno.land/std@0.157.0/path/mod.ts";
-import { copy } from "https://deno.land/std@0.157.0/fs/copy.ts";
-import {
-  checkInitialized,
-  getPrettyJSONString,
-  loadJSONC,
-  padPrivatePem,
-  padPublicPem,
-} from "../utils.ts";
+import { checkInitialized, getPrettyJSONString, loadJSONC } from "../utils.ts";
 import {
   BaseNodeEntrySpec,
   CNDIConfig,
@@ -14,297 +7,55 @@ import {
   DeploymentTargetConfiguration,
   KubernetesManifest,
   KubernetesSecret,
-  SealedSecretsKeys,
 } from "../types.ts";
 import getApplicationManifest from "../outputs/application-manifest.ts";
 import getTerraformNodeResource from "../outputs/terraform-node-resource.ts";
 import getTerraformRootFile from "../outputs/terraform-root-file.ts";
 import RootChartYaml from "../outputs/root-chart.ts";
-import getDotEnv from "../outputs/env.ts";
 import getSealedSecretManifest from "../outputs/sealed-secret-manifest.ts";
-import getReadme from "../outputs/readme.ts";
 
 import workerBootstrapTerrformTemplate from "../bootstrap/worker_bootstrap_cndi.sh.ts";
 import controllerBootstrapTerraformTemplate from "../bootstrap/controller_bootstrap_cndi.sh.ts";
-import { Secret } from "https://deno.land/x/cliffy@v0.25.4/prompt/secret.ts";
-import { Input } from "https://deno.land/x/cliffy@v0.25.4/prompt/mod.ts";
-import { cyan } from "https://deno.land/std@0.157.0/fmt/colors.ts";
 
-const createSealedSecretsKeys = async ({
-  pathToKeys,
-  pathToOpenSSL,
-}: CNDIContext): Promise<SealedSecretsKeys> => {
-  Deno.mkdir(pathToKeys, { recursive: true });
-  const sealed_secrets_public_key_path = path.join(pathToKeys, "public.pem");
-  const sealed_secrets_private_key_path = path.join(pathToKeys, "private.pem");
+import { loadSealedSecretsKeys } from "../initialize/sealedSecretsKeys.ts";
 
-  let sealed_secrets_private_key;
-  let sealed_secrets_public_key;
+import { loadTerraformStatePassphrase } from "../initialize/terraformStatePassphrase.ts";
 
-  const ranOpenSSLGenerateKeyPair = await Deno.run({
-    cmd: [
-      pathToOpenSSL,
-      "req",
-      "-x509",
-      "-nodes",
-      "-newkey",
-      "rsa:4096",
-      "-keyout",
-      sealed_secrets_private_key_path,
-      "-out",
-      sealed_secrets_public_key_path,
-      "-subj",
-      "/CN=sealed-secret/O=sealed-secret",
-    ],
-    stdout: "piped",
-    stderr: "piped",
-  });
-
-  const generateKeyPairStatus = await ranOpenSSLGenerateKeyPair.status();
-  const generateKeyPairStderr = await ranOpenSSLGenerateKeyPair.stderrOutput();
-
-  if (generateKeyPairStatus.code !== 0) {
-    Deno.stdout.write(generateKeyPairStderr);
-    Deno.exit(251); // arbitrary exit code
-  } else {
-    sealed_secrets_private_key = await Deno.readTextFile(
-      sealed_secrets_private_key_path,
-    );
-    sealed_secrets_public_key = await Deno.readTextFile(
-      sealed_secrets_public_key_path,
-    );
-    Deno.remove(pathToKeys, { recursive: true });
-  }
-
-  ranOpenSSLGenerateKeyPair.close();
-
-  return {
-    sealed_secrets_private_key,
-    sealed_secrets_public_key,
-  };
-};
-
-const loadSealedSecretsKeys = (): SealedSecretsKeys | null => {
-  const sealed_secrets_public_key_material = Deno.env
-    .get("SEALED_SECRETS_PUBLIC_KEY_MATERIAL")
-    ?.trim()
-    .replaceAll("_", "\n");
-  const sealed_secrets_private_key_material = Deno.env
-    .get("SEALED_SECRETS_PRIVATE_KEY_MATERIAL")
-    ?.trim()
-    .replaceAll("_", "\n");
-
-  if (!sealed_secrets_public_key_material) {
-    return null;
-  }
-
-  if (!sealed_secrets_private_key_material) {
-    return null;
-  }
-
-  const sealedSecrets = {
-    sealed_secrets_private_key: padPrivatePem(
-      sealed_secrets_private_key_material,
-    ),
-    sealed_secrets_public_key: padPublicPem(sealed_secrets_public_key_material),
-  };
-
-  return sealedSecrets;
-};
-
-const loadTerraformStatePassphrase = (): string | null => {
-  const terraform_state_passphrase = Deno.env
-    .get("TERRAFORM_STATE_PASSPHRASE")
-    ?.trim();
-
-  if (!terraform_state_passphrase) {
-    return null;
-  }
-
-  return terraform_state_passphrase;
-};
-
-const createTerraformStatePassphrase = (): string => {
-  return crypto.randomUUID();
-};
-
-const loadArgoUIReadonlyPassword = (): string | null => {
-  const argo_ui_readonly_password = Deno.env
-    .get("ARGO_UI_READONLY_PASSWORD")
-    ?.trim();
-
-  if (!argo_ui_readonly_password) {
-    return null;
-  }
-
-  return argo_ui_readonly_password;
-};
-
-const createArgoUIReadOnlyPassword = (): string => {
-  return crypto.randomUUID().replaceAll("-", "");
-};
-
-const updateGitIgnore = async (gitignorePath: string) => {
-  const dotEnvIgnoreEntry = "\n.env\n";
-  const dotKeysIgnoreEntry = "\n.keys/\n";
-  const terraformIgnoreEntry =
-    "\ncndi/terraform/.terraform*\ncndi/terraform/*.tfstate*\ncndi/terraform/.terraform/\n";
-  try {
-    const gitignoreContents = await Deno.readTextFile(gitignorePath);
-
-    // gitignore exists in user's project directory
-
-    if (!gitignoreContents.includes("env")) {
-      await Deno.writeTextFile(
-        gitignorePath,
-        gitignoreContents + dotEnvIgnoreEntry,
-      );
-    }
-
-    if (!gitignoreContents.includes(".keys")) {
-      await Deno.writeTextFile(
-        gitignorePath,
-        gitignoreContents + dotKeysIgnoreEntry,
-      );
-    }
-
-    if (!gitignoreContents.includes("terraform")) {
-      await Deno.writeTextFile(
-        gitignorePath,
-        gitignoreContents + terraformIgnoreEntry,
-      );
-    }
-  } catch {
-    // gitignore does not exist in user's project directory, create it
-    await Deno.writeTextFile(
-      gitignorePath,
-      "# cndi files\n" +
-        dotEnvIgnoreEntry +
-        dotKeysIgnoreEntry +
-        terraformIgnoreEntry,
-    );
-  }
-};
+import { loadArgoUIReadOnlyPassword } from "../initialize/argoUIReadOnlyPassword.ts";
 
 /**
  * COMMAND fn: cndi overwrite-with
  * Overwrites ./cndi directory with the specified config file
  */
 const overwriteWithFn = async (context: CNDIContext, initializing = false) => {
-  const {
-    pathToConfig,
-    githubDirectory,
-    noGitHub,
-    CNDI_SRC,
-    projectDirectory,
-    pathToKubernetesManifests,
-    pathToTerraformResources,
-    noDotEnv,
-    dotEnvPath,
-  } = context;
+  const { pathToConfig, pathToKubernetesManifests, pathToTerraformResources } =
+    context;
 
-  if (!initializing) {
-    console.log(`cndi overwrite-with -f "${pathToConfig}"`);
-  }
-
-  const sealedSecretsKeys = loadSealedSecretsKeys() ||
-    (await createSealedSecretsKeys(context));
-
-  const terraformStatePassphrase = loadTerraformStatePassphrase() ||
-    createTerraformStatePassphrase();
-
-  const argoUIReadonlyPassword = loadArgoUIReadonlyPassword() ||
-    createArgoUIReadOnlyPassword();
+  let sealedSecretsKeys;
+  let terraformStatePassphrase;
+  let argoUIReadOnlyPassword;
 
   if (initializing) {
-    const directoryContainsCNDIFiles = await checkInitialized(context);
+    sealedSecretsKeys = context.sealedSecretsKeys;
+    terraformStatePassphrase = context.terraformStatePassphrase;
+    argoUIReadOnlyPassword = context.argoUIReadOnlyPassword;
+  } else {
+    console.log(`cndi overwrite-with -f "${pathToConfig}"`);
+    sealedSecretsKeys = loadSealedSecretsKeys();
+    terraformStatePassphrase = loadTerraformStatePassphrase();
+    argoUIReadOnlyPassword = loadArgoUIReadOnlyPassword();
+  }
 
-    const shouldContinue = directoryContainsCNDIFiles
-      ? confirm(
-        "It looks like you have already initialized a cndi project in this directory. Overwrite existing artifacts?",
-      )
-      : true;
+  if (!sealedSecretsKeys) {
+    throw new Error(`ow: "sealedSecretsKeys" are undefined`);
+  }
 
-    if (!shouldContinue) {
-      Deno.exit(0);
-    }
+  if (!argoUIReadOnlyPassword) {
+    throw new Error(`ow: "argoUIReadOnlyPassword" is undefined`);
+  }
 
-    if (!noGitHub) {
-      try {
-        // overwrite the github workflows and readme, do not clobber other files
-        await copy(path.join(CNDI_SRC, "github"), githubDirectory, {
-          overwrite: true,
-        });
-      } catch (githubCopyError) {
-        console.log("failed to copy github integration files");
-        console.error(githubCopyError);
-      }
-    }
-
-    // update gitignore
-    const gitignorePath = path.join(projectDirectory, ".gitignore");
-    updateGitIgnore(gitignorePath);
-
-    if (!noDotEnv) {
-      let GIT_USERNAME = "";
-      let GIT_REPO = "";
-      let GIT_PASSWORD = "";
-      let AWS_REGION = "us-east-1";
-      let AWS_ACCESS_KEY_ID = "";
-      let AWS_SECRET_ACCESS_KEY = "";
-
-      if (context.interactive) {
-        GIT_USERNAME = (await Input.prompt({
-          message: cyan("Enter your GitHub username:"),
-          default: GIT_USERNAME,
-        })) as string;
-
-        GIT_REPO = (await Input.prompt({
-          message: cyan("Enter your GitHub repository URL:"),
-          default: GIT_REPO,
-        })) as string;
-
-        GIT_PASSWORD = (await Secret.prompt({
-          message: cyan("Enter your GitHub Personal Access Token:"),
-          default: GIT_PASSWORD,
-        })) as string;
-
-        AWS_REGION = (await Input.prompt({
-          message: cyan("Enter your AWS region:"),
-          default: AWS_REGION,
-        })) as string;
-
-        AWS_ACCESS_KEY_ID = (await Secret.prompt({
-          message: cyan("Enter your AWS access key ID:"),
-          default: AWS_ACCESS_KEY_ID,
-        })) as string;
-
-        AWS_SECRET_ACCESS_KEY = (await Secret.prompt({
-          message: cyan("Enter your AWS secret access key:"),
-          default: AWS_ACCESS_KEY_ID,
-        })) as string;
-      }
-
-      await Deno.writeTextFile(
-        dotEnvPath,
-        getDotEnv({
-          sealedSecretsKeys,
-          terraformStatePassphrase,
-          argoUIReadonlyPassword,
-          GIT_USERNAME,
-          GIT_REPO,
-          GIT_PASSWORD,
-          AWS_REGION,
-          AWS_ACCESS_KEY_ID,
-          AWS_SECRET_ACCESS_KEY,
-        }),
-      );
-    }
-
-    await Deno.writeTextFile(
-      path.join(projectDirectory, "README.md"),
-      getReadme(context),
-    );
+  if (!terraformStatePassphrase) {
+    throw new Error(`ow: "terraformStatePassphrase" is undefined`);
   }
 
   const config = (await loadJSONC(pathToConfig)) as unknown as CNDIConfig;

--- a/src/commands/overwrite-with.ts
+++ b/src/commands/overwrite-with.ts
@@ -1,5 +1,5 @@
 import * as path from "https://deno.land/std@0.157.0/path/mod.ts";
-import { checkInitialized, getPrettyJSONString, loadJSONC } from "../utils.ts";
+import { getPrettyJSONString, loadJSONC } from "../utils.ts";
 import {
   BaseNodeEntrySpec,
   CNDIConfig,

--- a/src/initialize/argoUIReadOnlyPassword.ts
+++ b/src/initialize/argoUIReadOnlyPassword.ts
@@ -1,0 +1,17 @@
+const loadArgoUIReadOnlyPassword = (): string | null => {
+  const argo_ui_readonly_password = Deno.env
+    .get("ARGO_UI_READONLY_PASSWORD")
+    ?.trim();
+
+  if (!argo_ui_readonly_password) {
+    return null;
+  }
+
+  return argo_ui_readonly_password;
+};
+
+const createArgoUIReadOnlyPassword = (): string => {
+  return crypto.randomUUID().replaceAll("-", "");
+};
+
+export { createArgoUIReadOnlyPassword, loadArgoUIReadOnlyPassword };

--- a/src/initialize/sealedSecretsKeys.ts
+++ b/src/initialize/sealedSecretsKeys.ts
@@ -1,0 +1,88 @@
+import { padPrivatePem, padPublicPem } from "../utils.ts";
+import * as path from "https://deno.land/std@0.157.0/path/mod.ts";
+
+import { CNDIContext, SealedSecretsKeys } from "../types.ts";
+
+const createSealedSecretsKeys = async ({
+  pathToKeys,
+  pathToOpenSSL,
+}: CNDIContext): Promise<SealedSecretsKeys> => {
+  Deno.mkdir(pathToKeys, { recursive: true });
+  const sealed_secrets_public_key_path = path.join(pathToKeys, "public.pem");
+  const sealed_secrets_private_key_path = path.join(pathToKeys, "private.pem");
+
+  let sealed_secrets_private_key;
+  let sealed_secrets_public_key;
+
+  const ranOpenSSLGenerateKeyPair = await Deno.run({
+    cmd: [
+      pathToOpenSSL,
+      "req",
+      "-x509",
+      "-nodes",
+      "-newkey",
+      "rsa:4096",
+      "-keyout",
+      sealed_secrets_private_key_path,
+      "-out",
+      sealed_secrets_public_key_path,
+      "-subj",
+      "/CN=sealed-secret/O=sealed-secret",
+    ],
+    stdout: "piped",
+    stderr: "piped",
+  });
+
+  const generateKeyPairStatus = await ranOpenSSLGenerateKeyPair.status();
+  const generateKeyPairStderr = await ranOpenSSLGenerateKeyPair.stderrOutput();
+
+  if (generateKeyPairStatus.code !== 0) {
+    Deno.stdout.write(generateKeyPairStderr);
+    Deno.exit(251); // arbitrary exit code
+  } else {
+    sealed_secrets_private_key = await Deno.readTextFile(
+      sealed_secrets_private_key_path,
+    );
+    sealed_secrets_public_key = await Deno.readTextFile(
+      sealed_secrets_public_key_path,
+    );
+    Deno.remove(pathToKeys, { recursive: true });
+  }
+
+  ranOpenSSLGenerateKeyPair.close();
+
+  return {
+    sealed_secrets_private_key,
+    sealed_secrets_public_key,
+  };
+};
+
+const loadSealedSecretsKeys = (): SealedSecretsKeys | null => {
+  const sealed_secrets_public_key_material = Deno.env
+    .get("SEALED_SECRETS_PUBLIC_KEY_MATERIAL")
+    ?.trim()
+    .replaceAll("_", "\n");
+  const sealed_secrets_private_key_material = Deno.env
+    .get("SEALED_SECRETS_PRIVATE_KEY_MATERIAL")
+    ?.trim()
+    .replaceAll("_", "\n");
+
+  if (!sealed_secrets_public_key_material) {
+    return null;
+  }
+
+  if (!sealed_secrets_private_key_material) {
+    return null;
+  }
+
+  const sealedSecrets = {
+    sealed_secrets_private_key: padPrivatePem(
+      sealed_secrets_private_key_material,
+    ),
+    sealed_secrets_public_key: padPublicPem(sealed_secrets_public_key_material),
+  };
+
+  return sealedSecrets;
+};
+
+export { createSealedSecretsKeys, loadSealedSecretsKeys };

--- a/src/initialize/terraformStatePassphrase.ts
+++ b/src/initialize/terraformStatePassphrase.ts
@@ -1,0 +1,17 @@
+const loadTerraformStatePassphrase = (): string | null => {
+  const terraform_state_passphrase = Deno.env
+    .get("TERRAFORM_STATE_PASSPHRASE")
+    ?.trim();
+
+  if (!terraform_state_passphrase) {
+    return null;
+  }
+
+  return terraform_state_passphrase;
+};
+
+const createTerraformStatePassphrase = (): string => {
+  return crypto.randomUUID().replaceAll("-", "");
+};
+
+export { createTerraformStatePassphrase, loadTerraformStatePassphrase };

--- a/src/outputs/env.ts
+++ b/src/outputs/env.ts
@@ -1,87 +1,26 @@
-import { DotEnvArgs } from "../types.ts";
-import { trimPemString } from "../utils.ts";
+import { EnvObject } from "../types.ts";
 
-const getDotEnv = ({
-  sealedSecretsKeys,
-  AWS_REGION,
-  AWS_ACCESS_KEY_ID,
-  AWS_SECRET_ACCESS_KEY,
-  GIT_REPO,
-  GIT_PASSWORD,
-  GIT_USERNAME,
-  terraformStatePassphrase,
-  argoUIReadonlyPassword,
-}: DotEnvArgs): string => {
-  // convert keys with padding into key material with "_" instead of line breaks
-  const SEALED_SECRETS_PUBLIC_KEY_MATERIAL = trimPemString(
-    sealedSecretsKeys.sealed_secrets_public_key,
-  ).replaceAll("\n", "_");
-  const SEALED_SECRETS_PRIVATE_KEY_MATERIAL = trimPemString(
-    sealedSecretsKeys.sealed_secrets_private_key,
-  ).replaceAll("\n", "_");
+const PLACEHOLDER_SUFFIX = "_PLACEHOLDER__";
 
-  // because in interactive mode these variables are required immediately
-  // we cannot rely on them having been loaded in from the .env file
-  const _AWS_REGION = "AWS_REGION";
-  const _AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID";
-  const _AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY";
+const writeEnvObject = async (
+  pathToDotEnv: string,
+  envObj: EnvObject,
+): Promise<void> => {
+  const dotEnvString = Object.keys(envObj)
+    .map((key) => {
+      const val = (
+        envObj[key]?.value ? envObj[key].value : `${key}${PLACEHOLDER_SUFFIX}`
+      ) as string;
 
-  Deno.env.set(_AWS_REGION, AWS_REGION);
-  Deno.env.set(_AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY_ID);
-  Deno.env.set(_AWS_SECRET_ACCESS_KEY, AWS_SECRET_ACCESS_KEY);
+      const comment = envObj[key]?.comment ? `\n# ${envObj[key].comment}` : "";
 
-  const _GIT_USERNAME = "GIT_USERNAME";
-  const _GIT_PASSWORD = "GIT_PASSWORD";
-  const _GIT_REPO = "GIT_REPO";
+      Deno.env.set(key, val);
 
-  Deno.env.set(_GIT_USERNAME, GIT_USERNAME);
-  Deno.env.set(_GIT_PASSWORD, GIT_PASSWORD);
-  Deno.env.set(_GIT_REPO, GIT_REPO);
+      return `${comment}\n${key}=${val}`;
+    })
+    .join("\n");
 
-  const _SEALED_SECRETS_PRIVATE_KEY_MATERIAL =
-    "SEALED_SECRETS_PRIVATE_KEY_MATERIAL";
-  const _SEALED_SECRETS_PUBLIC_KEY_MATERIAL =
-    "SEALED_SECRETS_PUBLIC_KEY_MATERIAL";
-
-  Deno.env.set(
-    _SEALED_SECRETS_PRIVATE_KEY_MATERIAL,
-    SEALED_SECRETS_PRIVATE_KEY_MATERIAL,
-  );
-  Deno.env.set(
-    _SEALED_SECRETS_PUBLIC_KEY_MATERIAL,
-    SEALED_SECRETS_PUBLIC_KEY_MATERIAL,
-  );
-
-  const _TERRAFORM_STATE_PASSPHRASE = "TERRAFORM_STATE_PASSPHRASE";
-
-  Deno.env.set(_TERRAFORM_STATE_PASSPHRASE, terraformStatePassphrase);
-
-  const _ARGO_UI_READONLY_PASSWORD = "ARGO_UI_READONLY_PASSWORD";
-
-  Deno.env.set(_ARGO_UI_READONLY_PASSWORD, argoUIReadonlyPassword);
-
-  // after all variables are set in the current environment
-  // write them to the .env file
-  return `# AWS Credentials
-${_AWS_REGION}=${AWS_REGION}
-${_AWS_ACCESS_KEY_ID}=${AWS_ACCESS_KEY_ID}
-${_AWS_SECRET_ACCESS_KEY}=${AWS_SECRET_ACCESS_KEY}
-
-# Git Credentials
-${_GIT_USERNAME}=${GIT_USERNAME}
-${_GIT_PASSWORD}=${GIT_PASSWORD}
-${_GIT_REPO}=${GIT_REPO}
-
-# Kubeseal Keypair
-${_SEALED_SECRETS_PRIVATE_KEY_MATERIAL}=${SEALED_SECRETS_PRIVATE_KEY_MATERIAL}
-${_SEALED_SECRETS_PUBLIC_KEY_MATERIAL}=${SEALED_SECRETS_PUBLIC_KEY_MATERIAL}
-
-# Terraform State Passphrase
-${_TERRAFORM_STATE_PASSPHRASE}=${terraformStatePassphrase}
-
-# ArgoCD UI Readonly Password
-${_ARGO_UI_READONLY_PASSWORD}=${argoUIReadonlyPassword}
-`;
+  await Deno.writeTextFile(pathToDotEnv, dotEnvString);
 };
 
-export default getDotEnv;
+export default writeEnvObject;

--- a/src/outputs/gitignore.ts
+++ b/src/outputs/gitignore.ts
@@ -1,0 +1,11 @@
+export default function getGitignore(): string {
+  const gitignoreContents = `
+# cndi
+.env
+.keys/
+cndi/terraform/.terraform*
+cndi/terraform/*.tfstate*
+cndi/terraform/.terraform/
+`;
+  return gitignoreContents.trim();
+}

--- a/src/outputs/readme.ts
+++ b/src/outputs/readme.ts
@@ -1,14 +1,8 @@
-import { CNDIContext } from "../types.ts";
-
 import coreReadmeBlock from "../doc/core.ts";
-
 import basicReadmeBlock from "../doc/basic.ts";
 import airflowTlsReadmeBlock from "../doc/airflow-tls.ts";
 
-const enum Template {
-  "airflow-tls" = "airflow-tls",
-  "basic" = "basic",
-}
+import { Template } from "../types.ts";
 
 type TemplateBlock = {
   [key in Template]: string;
@@ -23,8 +17,7 @@ ${airflowTlsReadmeBlock}
   basic: basicReadmeBlock,
 };
 
-const getREADME = (context: CNDIContext): string => {
-  const { template } = context;
+const getREADME = (template?: Template): string => {
   const templateBlock = templateBlocks[template as Template];
 
   // returns a readme which is the core readme block, and any template specific blocks

--- a/src/templates/airflow-tls.ts
+++ b/src/templates/airflow-tls.ts
@@ -1,5 +1,37 @@
-import { AirflowTlsTemplateAnswers } from "../types.ts";
+import { AirflowTlsTemplateAnswers, CNDIContext, EnvObject } from "../types.ts";
+import { Input } from "https://deno.land/x/cliffy@v0.25.4/prompt/mod.ts";
+import { Secret } from "https://deno.land/x/cliffy@v0.25.4/prompt/secret.ts";
+import { cyan } from "https://deno.land/std@0.158.0/fmt/colors.ts";
 import { getPrettyJSONString } from "../utils.ts";
+
+const getAirflowTlsTemplateEnvObject = async (
+  context: CNDIContext,
+): Promise<EnvObject> => {
+  let GIT_SYNC_USERNAME = "";
+  let GIT_SYNC_PASSWORD = "";
+
+  if (context.interactive) {
+    GIT_SYNC_USERNAME = (await Input.prompt({
+      message: cyan("Please enter your git username for Airflow DAG Storage:"),
+      default: GIT_SYNC_USERNAME,
+    })) as string;
+
+    GIT_SYNC_PASSWORD = (await Secret.prompt({
+      message: cyan("Please enter your git password for Airflow DAG Storage:"),
+      default: GIT_SYNC_PASSWORD,
+    })) as string;
+  }
+  const airflowTlsTemplateEnvObject = {
+    GIT_SYNC_USERNAME: {
+      comment: "airflow-git-credentials secret values for DAG Storage",
+      value: GIT_SYNC_USERNAME,
+    },
+    GIT_SYNC_PASSWORD: {
+      value: GIT_SYNC_PASSWORD,
+    },
+  };
+  return airflowTlsTemplateEnvObject;
+};
 
 export default function getAirflowTlsTemplate({
   argocdDomainName,
@@ -177,3 +209,5 @@ export default function getAirflowTlsTemplate({
     },
   });
 }
+
+export { getAirflowTlsTemplateEnvObject };

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,6 +264,12 @@ interface KubernetesSecret extends KubernetesManifest {
   isPlaceholder: boolean;
 }
 
+interface EnvObject {
+  [key: string]: {
+    value?: string;
+    comment?: string;
+  };
+}
 interface KubernetesSecretWithStringData extends KubernetesSecret {
   stringData: {
     [key: string]: string;
@@ -278,18 +284,6 @@ interface CNDIApplicationSpec {
   values: {
     [key: string]: unknown;
   };
-}
-
-interface DotEnvArgs {
-  sealedSecretsKeys: SealedSecretsKeys;
-  terraformStatePassphrase: string;
-  argoUIReadonlyPassword: string;
-  AWS_REGION: string;
-  AWS_ACCESS_KEY_ID: string;
-  AWS_SECRET_ACCESS_KEY: string;
-  GIT_USERNAME: string;
-  GIT_PASSWORD: string;
-  GIT_REPO: string;
 }
 
 interface CNDIContext {
@@ -314,6 +308,9 @@ interface CNDIContext {
   noKeys: boolean;
   template: string;
   interactive: boolean;
+  sealedSecretsKeys?: SealedSecretsKeys;
+  terraformStatePassphrase?: string;
+  argoUIReadOnlyPassword?: string;
 }
 
 // cndi-config.jsonc["nodes"]["entries"][*]
@@ -568,6 +565,10 @@ interface SealedSecretsKeys {
   sealed_secrets_private_key: string;
   sealed_secrets_public_key: string;
 }
+const enum Template {
+  "airflow-tls" = "airflow-tls",
+  "basic" = "basic",
+}
 
 export type {
   AirflowTlsTemplateAnswers,
@@ -582,11 +583,12 @@ export type {
   CNDINode,
   CNDINodesSpec,
   DeploymentTargetConfiguration,
-  DotEnvArgs,
+  EnvObject,
   KubernetesManifest,
   KubernetesSecret,
   KubernetesSecretWithStringData,
   SealedSecretsKeys,
+  Template,
   TerraformDependencies,
   TerraformRootFileData,
 };


### PR DESCRIPTION
- [x] rewrote init/ow logic now init writes files that are constant like `.env` `.gitignore` `README.md` `.github`  and ow writes to `./cndi`
- [x] `.env` now varies on a per-template basis, eg: the airflow tls template now includes `GIT_SYNC_USERNAME` and `GIT_SYNC_PASSWORD`
- [x] secrets are now included in the interactive prompts
- [x] error messages are surfaced for missing secret declarations
- [x] secrets with missing values are not created  